### PR TITLE
Changed default value for callback option to empty function instead of undefined

### DIFF
--- a/src/jquery.twinkle.js
+++ b/src/jquery.twinkle.js
@@ -16,12 +16,12 @@ MIT License
 			gap: 0,
 			effect: 'splash',
 			effectOptions: undefined,
-			callback: undefined
+			callback: function(){}
 		},
 		stopDefaults = {
 			id: undefined,
 			effectOptions: undefined,
-			callback: undefined
+			callback: function(){}
 		},
 		TwinkleEvent = function (offX, offY, element, posX, posY) {
 


### PR DESCRIPTION
Triggering error when trying to call undefined value (Line 169)
