### PR TITLE
Update to support jQuery 3

### DIFF
--- a/src/jquery.twinkle.js
+++ b/src/jquery.twinkle.js
@@ -111,7 +111,7 @@ function Twinkler() {
         var settings = $.extend({}, defaults, options);
         var delay = settings.delay;
         var $htmlElements = $(htmlElements);
-        var size = $htmlElements.size();
+        var size = $htmlElements.length;
 
         $htmlElements.each(function (idx) {
 
@@ -153,7 +153,7 @@ function Twinkler() {
         var settings = $.extend({}, stopDefaults, options);
         var delay = settings.delay;
         var $htmlElements = $(htmlElements);
-        var size = $htmlElements.size();
+        var size = $htmlElements.length;
 
         $htmlElements.each(function (idx) {
 


### PR DESCRIPTION
.size() was deprecated in jQuery 3, length property should be used instead.